### PR TITLE
spring-boot-http-gradle to 0.0.4

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -7,6 +7,9 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
   version: 2.3.82
+- name: spring-boot-http-gradle
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.4
 - name: spring-petclinic
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.2


### PR DESCRIPTION
Promote spring-boot-http-gradle to version 0.0.4